### PR TITLE
Implement switch to keep extractNativeLibs manifest option

### DIFF
--- a/src/main/java/com/reandroid/apkeditor/Options.java
+++ b/src/main/java/com/reandroid/apkeditor/Options.java
@@ -227,6 +227,8 @@ public class Options {
     protected static final String ARG_DESC_force="force delete output path";
     protected static final String ARG_cleanMeta = "-clean-meta";
     protected static final String ARG_DESC_cleanMeta = "cleans META-INF directory along with signature block";
+    protected static final String ARG_keepExtractNativeLibs = "-keep-extractnativelibs";
+    protected static final String ARG_DESC_keepExtractNativeLibs = "keeps android:ExtractNativeLibs during manifest sanitation";
 
     protected static final String ARG_sig = "-sig";
     protected static final String ARG_DESC_sig = "signatures directory path";

--- a/src/main/java/com/reandroid/apkeditor/merge/Merger.java
+++ b/src/main/java/com/reandroid/apkeditor/merge/Merger.java
@@ -80,7 +80,7 @@ public class Merger extends BaseCommand<MergerOptions> {
             logMessage("Clearing META-INF ...");
             clearMeta(mergedModule);
         }
-        sanitizeManifest(mergedModule);
+        sanitizeManifest(mergedModule, options.keepExtractNativeLibs);
         Util.addApkEditorInfo(mergedModule, getClass().getSimpleName());
         String message = mergedModule.refreshTable();
         if(message != null){
@@ -129,15 +129,17 @@ public class Merger extends BaseCommand<MergerOptions> {
         tmp = Util.ensureUniqueFile(tmp);
         return tmp;
     }
-    private void sanitizeManifest(ApkModule apkModule) {
+    private void sanitizeManifest(ApkModule apkModule, boolean keepExtractNativeLibs) {
         if(!apkModule.hasAndroidManifestBlock()){
             return;
         }
         AndroidManifestBlock manifest = apkModule.getAndroidManifestBlock();
         logMessage("Sanitizing manifest ...");
-        AndroidManifestHelper.removeAttributeFromManifestAndApplication(manifest,
-                AndroidManifestBlock.ID_extractNativeLibs,
-                this, AndroidManifestBlock.NAME_extractNativeLibs);
+        if (!keepExtractNativeLibs) {
+             AndroidManifestHelper.removeAttributeFromManifestAndApplication(manifest,
+                    AndroidManifestBlock.ID_extractNativeLibs,
+                    this, AndroidManifestBlock.NAME_extractNativeLibs);
+        }
         AndroidManifestHelper.removeAttributeFromManifestAndApplication(manifest,
                 AndroidManifestBlock.ID_isSplitRequired,
                 this, AndroidManifestBlock.NAME_isSplitRequired);

--- a/src/main/java/com/reandroid/apkeditor/merge/MergerOptions.java
+++ b/src/main/java/com/reandroid/apkeditor/merge/MergerOptions.java
@@ -25,6 +25,7 @@ import java.io.File;
 public class MergerOptions extends Options {
     public boolean validateResDir;
     public boolean cleanMeta;
+    public boolean keepExtractNativeLibs;
     public String resDirName;
     public MergerOptions(){
         super();
@@ -36,6 +37,7 @@ public class MergerOptions extends Options {
         parseResDirName(args);
         parseValidateResDir(args);
         parseCleanMeta(args);
+        parseKeepExtractNativeLibs(args);
         super.parse(args);
     }
     private void parseValidateResDir(String[] args) throws ARGException {
@@ -54,6 +56,9 @@ public class MergerOptions extends Options {
             file=getOutputApkFromInput(inputFile);
         }
         this.outputFile=file;
+    }
+    private void parseKeepExtractNativeLibs(String[] args) throws ARGException {
+        this.keepExtractNativeLibs=containsArg(ARG_keepExtractNativeLibs, false, args);
     }
     private File getOutputApkFromInput(File file){
         String name = file.getName();
@@ -96,6 +101,9 @@ public class MergerOptions extends Options {
         if(cleanMeta){
             builder.append("\n Keep meta: true");
         }
+        if(keepExtractNativeLibs){
+            builder.append("\n Keep android:extractNativeLibs: true");
+        }
         builder.append("\n ---------------------------- ");
         return builder.toString();
     }
@@ -112,7 +120,8 @@ public class MergerOptions extends Options {
         builder.append("\nFlags:\n");
         table=new String[][]{
                 new String[]{ARG_force, ARG_DESC_force},
-                new String[]{ARG_cleanMeta, ARG_DESC_cleanMeta}
+                new String[]{ARG_cleanMeta, ARG_DESC_cleanMeta},
+                new String[]{ARG_keepExtractNativeLibs, ARG_DESC_keepExtractNativeLibs}
         };
         StringHelper.printTwoColumns(builder, "   ", Options.PRINT_WIDTH, table);
         String jar = APKEditor.getJarName();


### PR DESCRIPTION
Introduce the CLI option to preserve  android:extractNativeLibraries to allow re-packing apps that initially ship with this setting (and some code relies on it!)

To repack such an application with apktool successfully, one needs to:

- put shared library extension (so) to `doNotCompress` section of `apktool.yml` in the decompiled app directory:

    ```
    doNotCompress:
    - so
    ```

* build APK back using `apktool b`

* zipalign using the `zipalign` tool from latest Android SDK:

    ```
    zipalign -p -f 4 app-rebuilt.apk                                                                                  
    ```

* sign APK by apksigner or uber-apk-signer skipping its own zipalign step:

    ```
    java -jar uber-apk-signer --skipZipAlign
    ```
