### PR TITLE
Remove splitTypes attributes from manifest when merging

### DIFF
--- a/src/main/java/com/reandroid/apkeditor/common/AndroidManifestHelper.java
+++ b/src/main/java/com/reandroid/apkeditor/common/AndroidManifestHelper.java
@@ -52,6 +52,21 @@ public class AndroidManifestHelper {
         }));
     }
 
+    public static void removeAttributeFromManifestByName(AndroidManifestBlock androidManifestBlock,
+                                                                 String resourceName, APKLogger logger){
+        ResXmlElement manifestElement = androidManifestBlock.getManifestElement();
+        if(manifestElement == null){
+            if(logger != null){
+                logger.logMessage("WARN: AndroidManifest don't have <manifest>");
+            }
+            return;
+        }
+            int removed = manifestElement.removeAttributesWithName(resourceName);
+            if (removed > 0 && logger != null) {
+                logger.logMessage("Removed-attribute : " + resourceName);
+        }
+    }
+
     public static void removeAttributeFromManifestAndApplication(AndroidManifestBlock androidManifestBlock,
                                                                  int resourceId, APKLogger logger, String nameForLogging){
         if(resourceId == 0){

--- a/src/main/java/com/reandroid/apkeditor/merge/Merger.java
+++ b/src/main/java/com/reandroid/apkeditor/merge/Merger.java
@@ -136,6 +136,10 @@ public class Merger extends BaseCommand<MergerOptions> {
         }
         AndroidManifestBlock manifest = apkModule.getAndroidManifest();
         logMessage("Sanitizing manifest ...");
+        AndroidManifestHelper.removeAttributeFromManifestByName(manifest,
+            AndroidManifest.NAME_requiredSplitTypes, this);
+        AndroidManifestHelper.removeAttributeFromManifestByName(manifest,
+            AndroidManifest.NAME_splitTypes, this);
         AndroidManifestHelper.removeAttributeFromManifestAndApplication(manifest,
                 AndroidManifest.ID_extractNativeLibs,
                 this, AndroidManifest.NAME_extractNativeLibs);


### PR DESCRIPTION
The main thing is in the title.
refs:
- https://github.com/google/bundletool/blob/master/src/main/java/com/android/tools/build/bundletool/model/ManifestEditor.java#L328
- https://github.com/google/bundletool/blob/master/src/main/java/com/android/tools/build/bundletool/model/ManifestEditor.java#L345
