### PR TITLE
Gracefully handle dex file decompilation errors, skip problematic dex

### DIFF
--- a/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
+++ b/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
@@ -32,6 +32,7 @@ import org.jf.dexlib2.Opcodes;
 import org.jf.dexlib2.VersionMap;
 import org.jf.dexlib2.dexbacked.DexBackedDexFile;
 import org.jf.dexlib2.dexbacked.raw.HeaderItem;
+import org.jf.util.ExceptionWithContext;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -116,8 +117,16 @@ public class SmaliDecompiler implements DexDecoder {
         options.debugInfo = !decompileOptions.noDexDebug;
         options.dumpMarkers = decompileOptions.dexMarkers;
         options.setCommentProvider(getComment());
-        DexBackedDexFile dexFile = getInputDexFile(inputSource, options);
-        Baksmali.disassembleDexFile(dexFile, dir, 1, options);
+        try {
+            DexBackedDexFile dexFile = getInputDexFile(inputSource, options);
+            Baksmali.disassembleDexFile(dexFile, dir, 1, options);
+        }catch (ExceptionWithContext exceptionWithContext){
+            logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exceptionWithContext.getMessage());
+            return;
+        }catch (IOException exception){
+            logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exception.getMessage());
+            return;
+        }
     }
     private void disassembleWithInternalDexLib(DexFileInputSource inputSource, File mainDir) throws IOException {
         Predicate<SectionType<?>> filter;

--- a/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
+++ b/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
@@ -37,7 +37,6 @@ import org.jf.util.ExceptionWithContext;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.lang.ArrayIndexOutOfBoundsException;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -123,9 +122,6 @@ public class SmaliDecompiler implements DexDecoder {
             Baksmali.disassembleDexFile(dexFile, dir, 1, options);
         }catch (ExceptionWithContext exceptionWithContext){
             logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exceptionWithContext.getMessage());
-            return;
-        }catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException){
-            logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+arrayIndexOutOfBoundsException.getMessage());
             return;
         }catch (IOException exception){
             logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exception.getMessage());

--- a/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
+++ b/src/main/java/com/reandroid/apkeditor/smali/SmaliDecompiler.java
@@ -37,6 +37,7 @@ import org.jf.util.ExceptionWithContext;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.ArrayIndexOutOfBoundsException;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -122,6 +123,9 @@ public class SmaliDecompiler implements DexDecoder {
             Baksmali.disassembleDexFile(dexFile, dir, 1, options);
         }catch (ExceptionWithContext exceptionWithContext){
             logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exceptionWithContext.getMessage());
+            return;
+        }catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException){
+            logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+arrayIndexOutOfBoundsException.getMessage());
             return;
         }catch (IOException exception){
             logMessage("Error decompiling dex file: "+inputSource.getAlias()+" ,"+exception.getMessage());


### PR DESCRIPTION
Some protectors/packers intentionally add useless/unwanted dex files under apk to hinder tools like apktool/apkeditor to fail during decompilation as they're not correct pure dex files(classes0.dex, there's no such thing as `classes0` in an apk file, generally dex files start with `classes.dex`, `classes2.dex` and so on..) which leads to the tools being not able to complete apk decompilation.

```shell
I: [DECOMPILE] Baksmali: classes0.dex

ERROR:
org.jf.util.ExceptionWithContext: Encountered small uint that is out of range at offset 0x70
        at org.jf.dexlib2.dexbacked.DexBuffer.readSmallUint(DexBuffer.java:59)
        at org.jf.dexlib2.dexbacked.model.DexStringSection.load(DexStringSection.java:44)
        at org.jf.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:98)
        at org.jf.dexlib2.dexbacked.DexBackedDexFile.<init>(DexBackedDexFile.java:204)
        at com.reandroid.apkeditor.smali.SmaliDecompiler.getInputDexFile(SmaliDecompiler.java:179)
        at com.reandroid.apkeditor.smali.SmaliDecompiler.disassembleWithJesusFrekeLib(SmaliDecompiler.java:119)
        at com.reandroid.apkeditor.smali.SmaliDecompiler.decodeDex(SmaliDecompiler.java:64)
        at com.reandroid.apk.DexDecoder.decodeDex(DexDecoder.java:29)
        at com.reandroid.apkeditor.smali.SmaliDecompiler.decodeDex(SmaliDecompiler.java:71)
        at com.reandroid.apk.ApkModuleDecoder.decodeDexFiles(ApkModuleDecoder.java:113)
        at com.reandroid.apk.ApkModuleDecoder.decode(ApkModuleDecoder.java:58)
        at com.reandroid.apkeditor.decompile.Decompiler.runCommand(Decompiler.java:62)
        at com.reandroid.apkeditor.Options.runCommand(Options.java:59)
        at com.reandroid.apkeditor.Main.run(Main.java:136)
        at com.reandroid.apkeditor.Main.execute(Main.java:72)
        at com.reandroid.apkeditor.Main.main(Main.java:57)
```

This commit enhances the `SmaliDecompiler` to gracefully handle errors encountered during the decompilation of individual dex files. Previously, encountering a malformed or invalid dex file would halt the entire decompilation process.

Upon encountering an error, instead of halting, it now logs the error and skips the problematic dex file, continuing the decompilation process with the other files.

After:
```shell
15.223 I: [DECOMPILE] Baksmali: classes.dex                                                                                                             
35.430 I: [DECOMPILE] Baksmali: classes0.dex
35.431 I: [DECOMPILE] Error decompiling dex file: classes0.dex ,Encountered small uint that is out of range at offset 0x70
35.432 I: [DECOMPILE] Baksmali: classes2.dex
51.508 I: [DECOMPILE] Baksmali: classes3.dex
01:03.749 I: [DECOMPILE] Baksmali: classes4.dex
01:12.818 I: [DECOMPILE] Baksmali: classes5.dex
01:12.932 I: [DECOMPILE] Baksmali: classes6.dex
01:14.688 I: [DECOMPILE] Baksmali: classes7.dex
01:14.716 I: [DECOMPILE] Baksmali: classes8.dex
01:14.834 I: [DECOMPILE] Extracting root files ...
```
