### PR TITLE
Fix duplicate `res/` directory in APK refactor output

### DIFF
--- a/src/main/java/com/reandroid/apkeditor/refactor/AutoRefactor.java
+++ b/src/main/java/com/reandroid/apkeditor/refactor/AutoRefactor.java
@@ -19,6 +19,7 @@ import com.reandroid.apk.APKLogger;
 import com.reandroid.apk.ApkModule;
 import com.reandroid.apk.ResFile;
 import com.reandroid.arsc.chunk.TableBlock;
+import com.reandroid.arsc.chunk.PackageBlock;
 import com.reandroid.identifiers.PackageIdentifier;
 import com.reandroid.identifiers.TableIdentifier;
 import com.reandroid.identifiers.TypeIdentifier;
@@ -42,9 +43,7 @@ public class AutoRefactor {
         int renameCount = 0;
         List<ResFile> resFileList = mApkModule.listResFiles();
         for(ResFile resFile:resFileList){
-            String path = resFile.buildPath();
-            path = path.startsWith(RefactorUtil.RES_DIR + "/") ? path
-                    : RefactorUtil.RES_DIR + "/" + path;
+            String path = resFile.buildPath(PackageBlock.RES_DIRECTORY_NAME);
             if(path.equals(resFile.getFilePath())){
                 continue;
             }

--- a/src/main/java/com/reandroid/apkeditor/refactor/AutoRefactor.java
+++ b/src/main/java/com/reandroid/apkeditor/refactor/AutoRefactor.java
@@ -42,7 +42,9 @@ public class AutoRefactor {
         int renameCount = 0;
         List<ResFile> resFileList = mApkModule.listResFiles();
         for(ResFile resFile:resFileList){
-            String path = RefactorUtil.RES_DIR + "/" + resFile.buildPath();
+            String path = resFile.buildPath();
+            path = path.startsWith(RefactorUtil.RES_DIR + "/") ? path
+                    : RefactorUtil.RES_DIR + "/" + path;
             if(path.equals(resFile.getFilePath())){
                 continue;
             }

--- a/src/main/java/com/reandroid/apkeditor/refactor/RefactorUtil.java
+++ b/src/main/java/com/reandroid/apkeditor/refactor/RefactorUtil.java
@@ -127,6 +127,4 @@ public class RefactorUtil {
     }
     private static final Pattern PATTERN_GOOD_NAME =Pattern.compile("^[A-Za-z]{2,15}[_.A-Za-z0-9]*$");
     private static final Pattern PATTERN_GENERATED_NAME=Pattern.compile("^.+_(0x[0-9a-f]{7,8})$");
-
-    public static final String RES_DIR="res";
 }


### PR DESCRIPTION
Previously:
```shell
$ java -jar build/libs/APKEditor-1.4.3.jar x -i input.apk -o out.apk
00.000 I: [REFACTOR] Using: APKEditor version 1.4.3, ARSCLib version 1.3.6
      -i = input.apk
      -o = out.apk  
 __________________ 
00.019 I: [REFACTOR] Loading apk: input.apk
00.165 I: [REFACTOR] Auto refactoring ...
00.166 I: [REFACTOR] Validating resource names ...
00.604 I: [REFACTOR] Initializing android framework ...
00.605 I: [REFACTOR] Loading android framework for version: 35
00.757 I: [REFACTOR] Initialized framework: android-35 (15)
00.834 I: [REFACTOR] All resource names are valid
00.834 I: [REFACTOR] Validating file paths ...
01.004 I: [REFACTOR] Auto renamed entries
01.239 I: [REFACTOR] Removed unused table strings
Table size changed = 1086216, 1113360
01.239 I: [REFACTOR] Writing apk ...
01.257 I: [REFACTOR] Buffering compress changed files ...
03.808 I: [REFACTOR] Writing files: 1001
03.999 I: [REFACTOR] Writing signature block ...                                                                             
04.052 I: [REFACTOR] Saved to: out.apk

$ unzip -l out.apk | grep 'res/'
      744  1981-01-01 01:01   res/res/drawable/mtrl_switch_thumb_unchecked.xml
      352  1981-01-01 01:01   res/res/layout/mtrl_calendar_day_of_week.xml
      712  1981-01-01 01:01   res/res/layout/mtrl_picker_header_selection_text.xml
      828  1981-01-01 01:01   res/res/drawable/indeterminate_static.xml
      281  1981-01-01 01:01   res/res/drawable-xhdpi/abc_btn_check_to_on_mtrl_000.png
      564  1981-01-01 01:01   res/res/drawable/mtrl_ic_arrow_drop_down.xml
     1252  1981-01-01 01:01   res/res/navigation/recordings.xml
      318  1981-01-01 01:01   res/res/drawable-xhdpi/abc_text_select_handle_right_mtrl.png
      616  1981-01-01 01:01   res/res/anim/design_bottom_sheet_slide_in.xml
     1056  1981-01-01 01:01   res/res/drawable/ic_filter.xml
      856  1981-01-01 01:01   res/res/drawable/ic_play.xml
     1876  1981-01-01 01:01   res/res/layout/fragment_logs_extended_copy.xml
     1216  1981-01-01 01:01   res/res/drawable/ic_adb.xml
      696  1981-01-01 01:01   res/res/drawable/material_ic_calendar_black_24dp.xml
     1088  1981-01-01 01:01   res/res/layout/image_frame.xml
      548  1981-01-01 01:01   res/res/mipmap-anydpi-v26/ic_launcher_round.xml
     1064  1981-01-01 01:01   res/res/drawable/abc_list_selector_holo_light.xml
     2544  1981-01-01 01:01   res/res/layout/preference_dropdown.xml
      267  1981-01-01 01:01   res/res/drawable-mdpi/abc_ab_share_pack_mtrl_alpha.9.png
      764  1981-01-01 01:01   res/res/menu/main_menu.xml
     ........
```

Now:

```shell
$ java -jar build/libs/APKEditor-1.4.3.jar x -i input.apk -o out.apk
00.000 I: [REFACTOR] Using: APKEditor version 1.4.3, ARSCLib version 1.3.6
      -i = input.apk
      -o = out.apk  
 __________________ 
00.019 I: [REFACTOR] Loading apk: input.apk
00.166 I: [REFACTOR] Auto refactoring ...
00.169 I: [REFACTOR] Validating resource names ...
00.578 I: [REFACTOR] Initializing android framework ...
00.578 I: [REFACTOR] Loading android framework for version: 35
00.720 I: [REFACTOR] Initialized framework: android-35 (15)
00.801 I: [REFACTOR] All resource names are valid
00.802 I: [REFACTOR] Validating file paths ...
00.906 I: [REFACTOR] Auto renamed entries
01.107 I: [REFACTOR] Removed unused table strings
Table size changed = 1086216, 1109852
01.107 I: [REFACTOR] Writing apk ...
01.126 I: [REFACTOR] Buffering compress changed files ...
03.664 I: [REFACTOR] Writing files: 1001
03.948 I: [REFACTOR] Writing signature block ...                                                                             
03.977 I: [REFACTOR] Saved to: out.apk

$ unzip -l out.apk | grep 'res/'
      744  1981-01-01 01:01   res/drawable/mtrl_switch_thumb_unchecked.xml
      352  1981-01-01 01:01   res/layout/mtrl_calendar_day_of_week.xml
      712  1981-01-01 01:01   res/layout/mtrl_picker_header_selection_text.xml
      828  1981-01-01 01:01   res/drawable/indeterminate_static.xml
      281  1981-01-01 01:01   res/drawable-xhdpi/abc_btn_check_to_on_mtrl_000.png
      564  1981-01-01 01:01   res/drawable/mtrl_ic_arrow_drop_down.xml
     1252  1981-01-01 01:01   res/navigation/recordings.xml
      318  1981-01-01 01:01   res/drawable-xhdpi/abc_text_select_handle_right_mtrl.png
      616  1981-01-01 01:01   res/anim/design_bottom_sheet_slide_in.xml
     1056  1981-01-01 01:01   res/drawable/ic_filter.xml
      856  1981-01-01 01:01   res/drawable/ic_play.xml
     1876  1981-01-01 01:01   res/layout/fragment_logs_extended_copy.xml
     1216  1981-01-01 01:01   res/drawable/ic_adb.xml
      696  1981-01-01 01:01   res/drawable/material_ic_calendar_black_24dp.xml
     1088  1981-01-01 01:01   res/layout/image_frame.xml
      548  1981-01-01 01:01   res/mipmap-anydpi-v26/ic_launcher_round.xml
     1064  1981-01-01 01:01   res/drawable/abc_list_selector_holo_light.xml
     2544  1981-01-01 01:01   res/layout/preference_dropdown.xml
      267  1981-01-01 01:01   res/drawable-mdpi/abc_ab_share_pack_mtrl_alpha.9.png
      764  1981-01-01 01:01   res/menu/main_menu.xml
     ........
```